### PR TITLE
Add CTD data release information for June 2025

### DIFF
--- a/pages/linksets/ctd.md
+++ b/pages/linksets/ctd.md
@@ -11,6 +11,17 @@ doi: [10.1093/nar/gkaa891](http://doi.org/10.1093/nar/gkaa891)
 
 *The linkset creation was supported by the funding from the European Union's Horizon 2020 research and innovation programme under the [EJP-RD](https://www.ejprarediseases.org/) COFUND-EJP N825575.*
 
+
+---
+
+### CTD data release June 2025
+
+The database content was retrieved from the [data download page](http://ctdbase.org/downloads/). Don’t forget to first unzip all link set files that you want to use and put them in the same folder.
+
+| Linkset | CTD version | Species | Interactions | Chemicals | Supported chemical identifiers | Proteins | Supported protein identifiers |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [CTD_ChemGene_June2025.xgmml]([https://ndownloader.figshare.com/files/26231723?private_link=e9263f8de7eea111c72d](https://figshare.com/ndownloader/files/59438846)) | 2025-06 | Homo sapiens (hsa) | 121,235 | 3,076 | ChEBI, ChEMBL, Wikidata, CAS | 9,816 | UniProt, NCBI Gene, Ensembl, HGNC |
+
 ---
 
 ### CTD data release 6 Jan 2021


### PR DESCRIPTION
Added details about the CTD data release for June 2025, including a new table with linkset information.